### PR TITLE
Version bump json gem dependency version 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,29 +3,29 @@ PATH
   specs:
     avatax-v1 (15.0.1)
       addressable (~> 2.3)
-      json (~> 1.8)
+      json (>= 2.3)
       rest-client (~> 1.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    domain_name (0.5.20180417)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    json (1.8.6)
+    json (2.3.1)
     mime-types (2.99.3)
     netrc (0.11.0)
-    public_suffix (3.0.3)
+    public_suffix (4.0.5)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.7)
 
 PLATFORMS
   ruby
@@ -34,4 +34,4 @@ DEPENDENCIES
   avatax-v1!
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://www.avalara.com/"
   s.license = 'Apache-2.0'
   s.description = "Provides a straightforward way to access and communicate with the all methods exposed by the Avalara AvaTax REST API."
-  s.add_dependency 'json', '~> 1.8'
+  s.add_dependency 'json', '>= 2.3'
   s.add_dependency 'rest-client', '~> 1.7'
   s.add_dependency 'addressable', '~> 2.3'
 end


### PR DESCRIPTION
**CVE-2013-0269**
https://github.com/advisories/GHSA-x457-cw4h-hq5f

> The JSON gem before 1.5.5, 1.6.x before 1.6.8, and 1.7.x before 1.7.7 for Ruby allows remote attackers to cause a denial of service (resource consumption) or bypass the mass assignment protection mechanism via a crafted JSON document that triggers the creation of arbitrary Ruby symbols or certain internal objects, as demonstrated by conducting a SQL injection attack against Ruby on Rails, aka "Unsafe Object Creation Vulnerability."
