### PR TITLE
[SECURITY] Version bump json gem dependency version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,29 +3,29 @@ PATH
   specs:
     avatax-v1 (15.0.1)
       addressable (~> 2.3)
-      json (~> 1.8)
+      json (>= 2.3)
       rest-client (~> 1.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    domain_name (0.5.20180417)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    json (1.8.6)
+    json (2.3.1)
     mime-types (2.99.3)
     netrc (0.11.0)
-    public_suffix (3.0.3)
+    public_suffix (4.0.5)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.7)
 
 PLATFORMS
   ruby
@@ -34,4 +34,4 @@ DEPENDENCIES
   avatax-v1!
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     avatax-v1 (15.0.1)
       addressable (~> 2.3)
       json
+      public_suffix (< 4.0)
       rest-client (~> 1.7)
 
 GEM
@@ -18,7 +19,7 @@ GEM
     json (2.3.1)
     mime-types (2.99.3)
     netrc (0.11.0)
-    public_suffix (4.0.5)
+    public_suffix (3.1.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     avatax-v1 (15.0.1)
       addressable (~> 2.3)
       json
-      public_suffix (< 4.0)
       rest-client (~> 1.7)
 
 GEM
@@ -19,7 +18,7 @@ GEM
     json (2.3.1)
     mime-types (2.99.3)
     netrc (0.11.0)
-    public_suffix (3.1.1)
+    public_suffix (4.0.5)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     avatax-v1 (15.0.1)
-      addressable
+      addressable (~> 2.3)
       json
       rest-client
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     avatax-v1 (15.0.1)
       addressable (~> 2.3)
       json
-      rest-client (~> 1.7)
+      rest-client (>= 1.7)
 
 GEM
   remote: https://rubygems.org/
@@ -13,16 +13,20 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.3.1)
-    mime-types (2.99.3)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     netrc (0.11.0)
     public_suffix (4.0.5)
-    rest-client (1.8.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     avatax-v1 (15.0.1)
       addressable (~> 2.3)
       json
-      rest-client
+      rest-client (~> 1.7)
 
 GEM
   remote: https://rubygems.org/
@@ -13,20 +13,16 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.3.1)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
+    mime-types (2.99.3)
     netrc (0.11.0)
     public_suffix (4.0.5)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
+    rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     avatax-v1 (15.0.1)
-      addressable (~> 2.3)
-      json (>= 2.3)
-      rest-client (~> 1.7)
+      addressable
+      json
+      rest-client
 
 GEM
   remote: https://rubygems.org/
@@ -13,16 +13,20 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.3.1)
-    mime-types (2.99.3)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     netrc (0.11.0)
     public_suffix (4.0.5)
-    rest-client (1.8.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -12,5 +12,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'rest-client', '~> 1.7'
   s.add_dependency 'addressable', '~> 2.3'
-  s.add_dependency 'public_suffix', '< 4.0'
 end

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.license = 'Apache-2.0'
   s.description = "Provides a straightforward way to access and communicate with the all methods exposed by the Avalara AvaTax REST API."
   s.add_dependency 'json'
-  s.add_dependency 'rest-client'
+  s.add_dependency 'rest-client', '~> 1.7'
   s.add_dependency 'addressable', '~> 2.3'
 end

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.description = "Provides a straightforward way to access and communicate with the all methods exposed by the Avalara AvaTax REST API."
   s.add_dependency 'json'
   s.add_dependency 'rest-client'
-  s.add_dependency 'addressable'
+  s.add_dependency 'addressable', '~> 2.3'
 end

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://www.avalara.com/"
   s.license = 'Apache-2.0'
   s.description = "Provides a straightforward way to access and communicate with the all methods exposed by the Avalara AvaTax REST API."
-  s.add_dependency 'json', '~> 1.8'
+  s.add_dependency 'json', '>= 2.3'
   s.add_dependency 'rest-client', '~> 1.7'
   s.add_dependency 'addressable', '~> 2.3'
 end

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://www.avalara.com/"
   s.license = 'Apache-2.0'
   s.description = "Provides a straightforward way to access and communicate with the all methods exposed by the Avalara AvaTax REST API."
-  s.add_dependency 'json', '>= 2.3'
-  s.add_dependency 'rest-client', '~> 1.7'
-  s.add_dependency 'addressable', '~> 2.3'
+  s.add_dependency 'json'
+  s.add_dependency 'rest-client'
+  s.add_dependency 'addressable'
 end

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'rest-client', '~> 1.7'
   s.add_dependency 'addressable', '~> 2.3'
+  s.add_dependency 'public_suffix', '< 4.0'
 end

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.license = 'Apache-2.0'
   s.description = "Provides a straightforward way to access and communicate with the all methods exposed by the Avalara AvaTax REST API."
   s.add_dependency 'json'
-  s.add_dependency 'rest-client', '~> 1.7'
+  s.add_dependency 'rest-client', '>= 1.7'
   s.add_dependency 'addressable', '~> 2.3'
 end


### PR DESCRIPTION
**CVE-2013-0269**
https://github.com/advisories/GHSA-x457-cw4h-hq5f

> The JSON gem before 1.5.5, 1.6.x before 1.6.8, and 1.7.x before 1.7.7 for Ruby allows remote attackers to cause a denial of service (resource consumption) or bypass the mass assignment protection mechanism via a crafted JSON document that triggers the creation of arbitrary Ruby symbols or certain internal objects, as demonstrated by conducting a SQL injection attack against Ruby on Rails, aka "Unsafe Object Creation Vulnerability."